### PR TITLE
Fix SQLite error in UPDATE statement

### DIFF
--- a/gigya_raas/src/EventSubscriber/GigyaRaasEventSubscriber.php
+++ b/gigya_raas/src/EventSubscriber/GigyaRaasEventSubscriber.php
@@ -30,7 +30,7 @@ class GigyaRaasEventSubscriber implements EventSubscriberInterface {
 		$cached_session_expiration = $gigya_raas_session->get('session_expiration');
 		if (($gigya_raas_session->get('session_registered') === FALSE) and $cached_session_expiration) {
 			Database::getConnection()
-				->query('UPDATE {sessions} s SET expiration = :expiration, is_remember_me = :is_remember_me WHERE s.uid = :uid AND s.sid = :sid',
+				->query('UPDATE {sessions} SET expiration = :expiration, is_remember_me = :is_remember_me WHERE uid = :uid AND sid = :sid',
 					[':expiration' => $cached_session_expiration, ':is_remember_me' => $is_remember_me, ':uid' => $uid, ':sid' => Crypt::hashBase64($drupal_session->getId())]);
 
 			try {


### PR DESCRIPTION
UPDATE statements in SQLite require the `AS` keyword for table alias https://www.sqlite.org/lang_update.html so it was triggering an error like this

`SQLSTATE[HY000]: General error: 1 near "s": syntax error: UPDATE {sessions} s SET expiration = :expiration, is_remember_me = :is_remember_me WHERE s.uid = :uid AND s.sid = :sid; Array
(
    [:expiration] => -1
    [:is_remember_me] => 0
    [:uid] => 11
    [:sid] => 3uVNmhW-ekICbY9-b8wpvHQZMSl9MaV3syYsUS8XjA4
)
`

There isn't actually a need for table alias in this statement so I removed it to prevent errors