### PR TITLE
Clean Drupal's packaging script information on info.yml files

### DIFF
--- a/gigya/gigya.info.yml
+++ b/gigya/gigya.info.yml
@@ -2,10 +2,5 @@ name: Gigya
 type: module
 description: 'Gigya core module'
 package: Gigya
-# core: 9.x
 configure: gigya.admin.form
-
-version: '9.x-1.1.1'
 core_version_requirement: ^8 || ^9
-project: 'gigya'
-datestamp: 1494803025

--- a/gigya_ds/gigya_ds.info.yml
+++ b/gigya_ds/gigya_ds.info.yml
@@ -5,8 +5,4 @@ package: Gigya
 dependencies:
   - gigya
   - gigya_raas
-# Information added by Drupal.org packaging script on 2017-05-14
-version: '9.x-1.1.1'
 core_version_requirement: ^8 || ^9
-project: 'gigya'
-datestamp: 1494803025

--- a/gigya_raas/gigya_raas.info.yml
+++ b/gigya_raas/gigya_raas.info.yml
@@ -5,9 +5,4 @@ package: Gigya
 configure: gigya.raas.config
 dependencies:
   - gigya
-
-# Information added by Drupal.org packaging script on 2017-05-14
-version: '9.x-1.1.1'
 core_version_requirement: ^8 || ^9
-project: 'gigya'
-datestamp: 1494803025

--- a/gigya_user_deletion/gigya_user_deletion.info.yml
+++ b/gigya_user_deletion/gigya_user_deletion.info.yml
@@ -3,8 +3,6 @@ type: module
 description: 'Allows permanently deleting users from Gigya and Drupal databases'
 package: Gigya
 configure: gigya.cron.form
-version: '9.x-1.1.1'
 core_version_requirement: ^8 || ^9
-project: 'gigya'
 dependencies:
   - gigya


### PR DESCRIPTION
Please refer to https://www.drupal.org/docs/creating-custom-modules/let-drupal-know-about-your-module-with-an-infoyml-file#s-complete-example at the end of this section you can see that `vesion` and `project`  are restricted properties which should only be added by Drupal packaging system.

Moreover, core's update module uses these properties to determine the project's update status which results in an `Unsupported` report for gigya module as it was marked like that on drupal.org

This PR also removes `datestamp` property cause it is also useless now as it is also used by update module to look for changes in project status.