### PR TITLE
Fix composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "gigya/drupal",
+  "name": "drupal/gigya",
   "description": "Gigya Drupal module",
   "license": "MIT",
   "authors": [

--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,16 @@
   ],
   "repositories": [
     {
-      "type": "vcs",
-      "url": "https://github.com/sap/gigya-php-sdk"
+      "type": "package",
+      "package": {
+        "name": "gigya/php-sdk",
+        "version": "3.0.1",
+        "type": "library",
+        "dist": {
+          "url": "https://github.com/SAP/gigya-php-sdk/archive/3.0.1.zip",
+          "type": "zip"
+        }
+      }
     }
   ],
   "minimum-stability": "dev",


### PR DESCRIPTION
`composer.json` file should be placed in project's root folder, otherwise composer won't resolve dependencies.

Changed repository type to `package` for `gigya/php-sdk` to allow resolving version constraint `"^3.0"` as defined in `composer.json`

Also changed project's name from `gigya/drupal` to `drupal/gigya` to follow the standard used by drupal modules.
