### PR TITLE
Add secure flag to cookies and remove expire time.

### DIFF
--- a/gigya/src/Helper/GigyaHelper.php
+++ b/gigya/src/Helper/GigyaHelper.php
@@ -280,7 +280,7 @@ class GigyaHelper implements GigyaHelperInterface {
   }
 
   public function saveUserLogoutCookie() {
-    user_cookie_save(array('gigya' => 'gigyaLogOut'));
+		setrawcookie('Drupal.visitor.gigya', 'gigyaLogOut', 0, '/', NULL, TRUE);
   }
 
   public function getUidByMail($mail) {

--- a/gigya_raas/src/GigyaController.php
+++ b/gigya_raas/src/GigyaController.php
@@ -424,7 +424,7 @@
 						else {
 							$session_sig = $this->getDynamicSessionSignatureUserSigned($token, $session_expiration, $app_key, $auth_key);
 						}
-						setrawcookie('gltexp_' . $api_key, rawurlencode($session_sig), time() + (10 * 365 * 24 * 60 * 60), '/', $request->getHost());
+						setrawcookie('gltexp_' . $api_key, rawurlencode($session_sig), 0, '/', $request->getHost(), TRUE);
 					}
 				}
 			}


### PR DESCRIPTION
To enhance security it is recommended to set "Secure" flag in cookies to be only sent over HTTPS and to set Expires=0 to keep cookies only during session lifetime.