### PR TITLE
Add type in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
   "name": "gigya/drupal",
+  "type": "drupal-module",
   "description": "Gigya Drupal module",
   "license": "MIT",
   "authors": [


### PR DESCRIPTION
The composer.json does not have a type key which means that the module isn't added to the right folder (modules/contrib) when pulling it via composer require.