### PR TITLE
Add missing config schema for 'Gigya RaaS Custom Screen-Set' block

### DIFF
--- a/gigya_raas/config/schema/gigya_raas.schema.yml
+++ b/gigya_raas/config/schema/gigya_raas.schema.yml
@@ -69,3 +69,23 @@ gigya_raas.screensets:
         custom_screensets:
           type: string
           label: Custom / Consent Screen-Sets
+
+block.settings.gigya_raas_custom_screenset:
+  type: block_settings
+  label: 'Gigya RaaS Custom Screen-Set block'
+  mapping:
+    display_type:
+      type: string
+      label: 'Display Type'
+    desktop_screenset:
+      type: string
+      label: 'Desktop Screen-Set'
+    container_id:
+      type: string
+      label: 'Container ID'
+    link_id:
+      type: string
+      label: 'Link ID'
+    link_class:
+      type: string
+      label: 'Link CSS Class'


### PR DESCRIPTION
Config schema is missing for 'Gigya RaaS Custom Screen-Set' block

![изображение](https://user-images.githubusercontent.com/4222740/118476308-25c5d480-b72f-11eb-9f45-502668d0af5a.png)

This PR is fixing this issue