### PR TITLE
Replace window.location.origin with a drupalSettings variable

### DIFF
--- a/gigya_raas/gigya_raas.module
+++ b/gigya_raas/gigya_raas.module
@@ -113,6 +113,9 @@ function gigya_raas_page_attachments(array &$attachments) {
 			}
 			$attachments['#attached']['drupalSettings']['gigya']['raas']['customScreenSets'] = $custom_screensets;
 
+      // Provide JS window.location.origin from server side to prevent XSS vulnerability.
+      $attachments['#attached']['drupalSettings']['gigya']['raas']['origin'] = Drupal::request()->getSchemeAndHttpHost();
+
       $attachments['#attached']['library'][] = 'gigya_raas/gigyaRaas';
     }
   }

--- a/gigya_raas/js/gigyaRaas.js
+++ b/gigya_raas/js/gigyaRaas.js
@@ -46,7 +46,7 @@
 		 */
 
 		if (!redirectTarget.startsWith('http'))
-			redirectTarget = window.location.origin + drupalSettings.path.baseUrl + redirectTarget;
+			redirectTarget = drupalSettings.gigya.raas.origin + drupalSettings.path.baseUrl + redirectTarget;
 
 		if (typeof sendSetSSOToken === 'undefined' || sendSetSSOToken === false)
 			location.replace(redirectTarget);
@@ -56,7 +56,7 @@
 
 	jQuery.fn.logoutRedirect = function (redirectTarget) {
 		if (!redirectTarget.startsWith('http'))
-			redirectTarget = window.location.origin + drupalSettings.path.baseUrl + redirectTarget;
+			redirectTarget = drupalSettings.gigya.raas.origin + drupalSettings.path.baseUrl + redirectTarget;
 
 		document.location = redirectTarget;
 	};


### PR DESCRIPTION
Replace window.location.origin with a drupalSettings variable provided from server side. This prevents vulnerability to XSS attacks.