### PR TITLE
Fix false response error.

### DIFF
--- a/gigya_raas/src/GigyaController.php
+++ b/gigya_raas/src/GigyaController.php
@@ -442,7 +442,7 @@ class GigyaController extends ControllerBase {
 
       return $response;
     }
-    return FALSE;
+    return new AjaxResponse();
   }
 
   /**


### PR DESCRIPTION
Why this PR:
I'm facing 5xx error when user rejects cookies, Drupal error says that getting FALSE in response which is unexpected. This PR fixes this issue and returns a AjaxResponse object.