### PR TITLE
Add signedInAlertResponse() to handle already-authenticated users issue #161

### DIFF
--- a/gigya_raas/src/GigyaController.php
+++ b/gigya_raas/src/GigyaController.php
@@ -117,7 +117,8 @@ class GigyaController extends ControllerBase {
    * @param \Symfony\Component\HttpFoundation\Request $request
    *   The incoming request object.
    *
-   * @return bool|AjaxResponse    The Ajax response
+   * @return \Drupal\Core\Ajax\AjaxResponse
+   *   The Ajax response
    *
    * @throws \Drupal\Core\Entity\EntityStorageException
    */
@@ -438,7 +439,8 @@ class GigyaController extends ControllerBase {
 
       return $response;
     }
-    return FALSE;
+
+    return $this->signedInAlertResponse();
   }
 
   /**
@@ -729,6 +731,26 @@ class GigyaController extends ControllerBase {
     }
 
     return $phoneNumber;
+  }
+
+  /**
+   * Ajax alert shown when an already-authenticated user attempts to log in.
+   *
+   * This method logs and returns an Ajax response containing an alert
+   * message to inform the user that they are already signed in.
+   *
+   * @return \Drupal\Core\Ajax\AjaxResponse
+   *   The Ajax response with an alert command.
+   */
+  protected function signedInAlertResponse(): AjaxResponse {
+    // Log the event for debugging.
+    \Drupal::logger('gigya_raas')->notice('User attempted to log in while already authenticated.');
+
+    // Return the AjaxResponse with alert.
+    $response = new AjaxResponse();
+    $response->addCommand(new AlertCommand($this->t("You're already signed in.")));
+
+    return $response;
   }
 
 }


### PR DESCRIPTION
This PR applies fixes originally prepared as a patch. The changes address issues when an already-authenticated user attempts to log in again.

Changes included:

> - Adds signedInAlertResponse() to return an empty AjaxResponse with an alert for already-signed-in users.
> - Prevents warnings and errors caused by controllers returning boolean instead of a Response.
> - Ensures consistent fallback response for authenticated users.

Notes:

> - The original patch is not included in this PR, All changes are applied directly to the code.
> - Tested locally to verify correct behavior.
> - Reference: fixes were originally generated as a patch base from the 1.91 updated module.