### PR TITLE
Optimize gigya script loading

### DIFF
--- a/gigya/gigya.libraries.yml
+++ b/gigya/gigya.libraries.yml
@@ -1,5 +1,6 @@
 drupalGigya:
   version: VERSION
+  header: true
   js:
     js/gigyaHelper.js: {}
     js/gigya.js: {}
@@ -7,8 +8,4 @@ drupalGigya:
     component:
       css/gigya.css: {}
   dependencies:
-    - core/jquery
-    - core/jquery.once
-    - core/drupal
     - core/drupalSettings
-    - core/drupal.ajax

--- a/gigya/js/gigya.js
+++ b/gigya/js/gigya.js
@@ -1,30 +1,18 @@
 /**
  * @file
- * Handles AJAX submission and response in Views UI.
+ * Initialises the Gigya script.
  */
 
-(function ($, Drupal, drupalSettings) {
+(function (drupalSettings) {
 
   'use strict';
 
-    /**
-     * @property drupalSettings.gigya.globalParameters
-     * @property drupalSettings.gigya.apiKey
-     * @property drupalSettings.gigya.dataCenter
-     */
-    var init = function () {
-    window.__gigyaConf = drupalSettings.gigya.globalParameters;
+  /**
+   * @property drupalSettings.gigya.globalParameters
+   * @property drupalSettings.gigya.apiKey
+   * @property drupalSettings.gigya.dataCenter
+   */
+  window.__gigyaConf = drupalSettings.gigya.globalParameters;
+  gigyaHelper.addGigyaScript(drupalSettings.gigya.apiKey, drupalSettings.gigya.lang, drupalSettings.gigya.dataCenter);
 
-    gigyaHelper.addGigyaScript(drupalSettings.gigya.apiKey, drupalSettings.gigya.lang, drupalSettings.gigya.dataCenter);
-    drupalSettings.gigya.isInit = true;
-  };
-
-  Drupal.behaviors.gigyaInit = {
-    attach: function (context, settings) {
-      if (!('isInit' in drupalSettings.gigya)) {
-        init();
-      }
-    }
-  };
-
-})(jQuery, Drupal, drupalSettings);
+})(drupalSettings);


### PR DESCRIPTION
Currently the remote gigya.js file is loaded by `Drupal.behaviors` once the page is loaded. The recommendation for better performance is to load it in `<head>` with the `async` attribute.

There are also a lot of unused dependencies in the library definition that we don't need. From what I can tell:

- `core/jquery` is only used for this `onLoginHandler` example that is never used
- `core/jquery.once` is never used
- `core/drupal` is only used for `Drupal.behaviors` which is removed in this PR
- `core/drupal.ajax` is never used, but AJAX was references in the file comment, which appears to be copy pasta